### PR TITLE
Add DVTPlugInCompatibilityUUIDs for Xcode 6.4 betas 1, 2.

### DIFF
--- a/DerivedData Exterminator/DMMDerivedDataExterminator.m
+++ b/DerivedData Exterminator/DMMDerivedDataExterminator.m
@@ -41,16 +41,15 @@ static NSInteger const DMMToolbarRoundedMinorVersion = 10;
 {
     if (self = [super init]) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateToolbarsFromPreferences) name:NSWindowDidBecomeKeyNotification object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidFinishLaunching:) name:NSApplicationDidFinishLaunchingNotification object:nil];
-		
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidFinishLaunching:) name:NSApplicationDidFinishLaunchingNotification object:nil];
     }
     return self;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-	[self createMenuItems];
-	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
+    [self createMenuItems];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
 }
 
 - (void)createMenuItems

--- a/DerivedData Exterminator/DMMDerivedDataExterminator.m
+++ b/DerivedData Exterminator/DMMDerivedDataExterminator.m
@@ -41,9 +41,16 @@ static NSInteger const DMMToolbarRoundedMinorVersion = 10;
 {
     if (self = [super init]) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateToolbarsFromPreferences) name:NSWindowDidBecomeKeyNotification object:nil];
-        [self createMenuItems];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidFinishLaunching:) name:NSApplicationDidFinishLaunchingNotification object:nil];
+		
     }
     return self;
+}
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification
+{
+	[self createMenuItems];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
 }
 
 - (void)createMenuItems

--- a/DerivedData Exterminator/Info.plist
+++ b/DerivedData Exterminator/Info.plist
@@ -32,6 +32,8 @@
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2013 Delisa Mason.</string>


### PR DESCRIPTION
This includes the new `DVTPlugInCompatibilityUUID` value from the following command: 

```
$ defaults read /Applications/Xcode-beta.app/Contents/Info DVTPlugInCompatibilityUUID
```

The first value is from beta 1, the second from beta 2.