### PR TITLE
Fix crash using Xcode 7 beta

### DIFF
--- a/DerivedData Exterminator/DMMButtonViewController.m
+++ b/DerivedData Exterminator/DMMButtonViewController.m
@@ -5,4 +5,7 @@
 
 - (void)invalidate {}
 
+/** Override -loadView to prevent an exception being raised because there is no nib for this view controller. */
+- (void)loadView {}
+
 @end

--- a/DerivedData Exterminator/DMMDerivedDataExterminator.m
+++ b/DerivedData Exterminator/DMMDerivedDataExterminator.m
@@ -197,7 +197,7 @@ static NSInteger const DMMToolbarRoundedMinorVersion = 10;
         exterminatorItem.image = image;
     }
 
-    [exterminatorItem setValue:[DMMButtonViewController new] forKey:@"viewController"];
+    [exterminatorItem setValue:[[DMMButtonViewController alloc] initWithNibName:nil bundle:nil] forKey:@"viewController"];
     return exterminatorItem;
 }
 


### PR DESCRIPTION
- Override the loadView method in DMMButtonViewController.m to prevent
an exception from being raised because the view controller does not
have a nib.
- Call the NSViewController designated initializer instead of +new

Fixes #37